### PR TITLE
Feat: 장바구니 서비스 - 장바구니 담기, 장바구니 조회 기능 개발 (#15)

### DIFF
--- a/src/main/java/com/example/miniprojectbe/controller/BasketController.java
+++ b/src/main/java/com/example/miniprojectbe/controller/BasketController.java
@@ -1,0 +1,29 @@
+package com.example.miniprojectbe.controller;
+
+import com.example.miniprojectbe.service.BasketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+
+@RestController
+@RequiredArgsConstructor
+public class BasketController {
+
+    private final BasketService basketService;
+
+    // 상품 장바구니 담기
+    @PostMapping("/api/cart")
+    public HashMap<String, String> addCart(@RequestHeader(name = "Authorization") String header, Long itemId) {
+        return basketService.addCart(header, itemId);
+    }
+
+    // 장바구니 조회
+    @GetMapping("/api/cartList")
+    public HashMap<String, Object> getCartList(@RequestHeader(name = "Authorization") String header) {
+        return basketService.getCartList(header);
+    }
+}

--- a/src/main/java/com/example/miniprojectbe/dto/BasketId.java
+++ b/src/main/java/com/example/miniprojectbe/dto/BasketId.java
@@ -12,6 +12,6 @@ import java.io.Serializable;
 @EqualsAndHashCode
 public class BasketId implements Serializable {
 
-    private Long member;
+    private String member;
     private Long item;
 }

--- a/src/main/java/com/example/miniprojectbe/dto/BasketResponseDTO.java
+++ b/src/main/java/com/example/miniprojectbe/dto/BasketResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.miniprojectbe.dto;
+
+import com.example.miniprojectbe.entity.Basket;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class BasketResponseDTO {
+
+    private Long basketId;
+    private Long itemId;
+    private String category;
+    private String bank;
+    private String itemName;
+    private String type;
+
+    public BasketResponseDTO(Basket basket) {
+        this.basketId = basket.getBasket();
+        this.itemId = basket.getItem().getItemId();
+        this.category = basket.getItem().getCategory();
+        this.bank = basket.getItem().getBank();
+        this.itemName = basket.getItem().getItemName();
+        this.type = basket.getItem().getType();
+    }
+}

--- a/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
@@ -1,0 +1,14 @@
+package com.example.miniprojectbe.repository;
+
+import com.example.miniprojectbe.dto.BasketId;
+import com.example.miniprojectbe.entity.Basket;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BasketRepository extends JpaRepository<Basket, BasketId> {
+
+    @EntityGraph(attributePaths = {"member", "item"})
+    List<Basket> findByMember_MemberId(String memberId);
+}

--- a/src/main/java/com/example/miniprojectbe/repository/ItemRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/ItemRepository.java
@@ -1,0 +1,11 @@
+package com.example.miniprojectbe.repository;
+
+import com.example.miniprojectbe.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    Optional<Item> findByItemId(Long itemId);
+}

--- a/src/main/java/com/example/miniprojectbe/service/BasketService.java
+++ b/src/main/java/com/example/miniprojectbe/service/BasketService.java
@@ -1,0 +1,9 @@
+package com.example.miniprojectbe.service;
+
+import java.util.HashMap;
+
+public interface BasketService {
+
+    HashMap<String, String> addCart(String header, Long itemId);
+    HashMap<String, Object> getCartList(String header);
+}

--- a/src/main/java/com/example/miniprojectbe/service/ItemService.java
+++ b/src/main/java/com/example/miniprojectbe/service/ItemService.java
@@ -2,7 +2,6 @@ package com.example.miniprojectbe.service;
 
 import com.example.miniprojectbe.entity.Item;
 
-import java.util.Optional;
 
 public interface ItemService {
     Item findItemByItemId(Long itemId);

--- a/src/main/java/com/example/miniprojectbe/service/ItemService.java
+++ b/src/main/java/com/example/miniprojectbe/service/ItemService.java
@@ -1,0 +1,9 @@
+package com.example.miniprojectbe.service;
+
+import com.example.miniprojectbe.entity.Item;
+
+import java.util.Optional;
+
+public interface ItemService {
+    Item findItemByItemId(Long itemId);
+}

--- a/src/main/java/com/example/miniprojectbe/service/MemberService.java
+++ b/src/main/java/com/example/miniprojectbe/service/MemberService.java
@@ -1,8 +1,8 @@
 package com.example.miniprojectbe.service;
 
-import com.example.miniprojectbe.dto.MailDTO;
 import com.example.miniprojectbe.dto.MemberRequestDTO;
 import com.example.miniprojectbe.dto.MemberLoginDTO;
+import com.example.miniprojectbe.entity.Member;
 
 import java.util.HashMap;
 
@@ -13,4 +13,5 @@ public interface MemberService {
     HashMap<String, String> saveHeaderTokenToBlackList(String header);
     boolean checkEmailDuplicate(String memberId);
     String findPassword(String memberId, String name);
+    Member findMemberByMemberId(String memberId);
 }

--- a/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
@@ -1,0 +1,86 @@
+package com.example.miniprojectbe.service.impl;
+
+import com.example.miniprojectbe.dto.BasketResponseDTO;
+import com.example.miniprojectbe.dto.MemberLoginDTO;
+import com.example.miniprojectbe.entity.Basket;
+import com.example.miniprojectbe.entity.Item;
+import com.example.miniprojectbe.entity.Member;
+import com.example.miniprojectbe.jwt.JwtProvider;
+import com.example.miniprojectbe.repository.BasketRepository;
+import com.example.miniprojectbe.service.BasketService;
+import com.example.miniprojectbe.service.ItemService;
+import com.example.miniprojectbe.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BasketServiceImpl implements BasketService {
+
+    private final BasketRepository basketRepository;
+    private final MemberService memberService;
+    private final ItemService itemService;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public HashMap<String, String> addCart(String header, Long itemId) {
+        try {
+            String memberId = getMemberIdByHeader(header);
+
+            Member member = memberService.findMemberByMemberId(memberId);
+            Item item = itemService.findItemByItemId(itemId);
+
+            Basket basket = Basket.builder().member(member).item(item).build();
+            basketRepository.save(basket);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return returnFailed();
+        }
+        return returnSuccess();
+    }
+
+    @Override
+    public HashMap<String, Object> getCartList(String header) {
+
+        HashMap<String, Object> result = new HashMap<>();
+
+        try {
+            String memberId = getMemberIdByHeader(header);
+            List<BasketResponseDTO> basketResponseDTOS = basketRepository.findByMember_MemberId(memberId)
+                    .stream()
+                    .map(BasketResponseDTO::new)
+                    .collect(Collectors.toList());
+
+            result.put("resultCode", "success");
+            result.put("resultData", basketResponseDTOS);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            result.put("resultCode", "failed");
+            return result;
+        }
+        return result;
+    }
+
+    private String getMemberIdByHeader(String header) {
+        MemberLoginDTO memberLoginDTO = jwtProvider.getMemberDTO(header);
+        return memberLoginDTO.getMemberId();
+    }
+
+    private HashMap<String, String> returnFailed() {
+        HashMap<String, String> result = new HashMap<>();
+        result.put("resultCode", "failed");
+        return result;
+    }
+
+    private HashMap<String, String> returnSuccess() {
+        HashMap<String, String> result = new HashMap<>();
+        result.put("resultCode", "success");
+        return result;
+    }
+}

--- a/src/main/java/com/example/miniprojectbe/service/impl/ItemServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/ItemServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.miniprojectbe.service.impl;
 
 import com.example.miniprojectbe.entity.Item;
-import com.example.miniprojectbe.entity.Member;
 import com.example.miniprojectbe.repository.ItemRepository;
 import com.example.miniprojectbe.service.ItemService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/miniprojectbe/service/impl/ItemServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/ItemServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.miniprojectbe.service.impl;
+
+import com.example.miniprojectbe.entity.Item;
+import com.example.miniprojectbe.entity.Member;
+import com.example.miniprojectbe.repository.ItemRepository;
+import com.example.miniprojectbe.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ItemServiceImpl implements ItemService {
+
+    private final ItemRepository itemRepository;
+
+    @Override
+    public Item findItemByItemId(Long itemId) {
+        try {
+            Item findItem = itemRepository.findByItemId(itemId).get();
+            return findItem;
+        } catch (NoSuchElementException e) {
+            log.error("해당 itemId와 일치하는 상품이 없습니다.");
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/example/miniprojectbe/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/MemberServiceImpl.java
@@ -95,6 +95,16 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
+    @Override
+    public Member findMemberByMemberId(String memberId) {
+        try {
+            Member findMember = memberRepository.findByMemberId(memberId).get();
+            return findMember;
+        } catch (NoSuchElementException e) {
+            log.error("해당 memberId와 일치하는 회원이 없습니다.");
+            return null;
+        }
+    }
 
     private boolean isValidPassword(MemberLoginDTO memberLoginDTO, Member findMember) {
         return passwordEncoder.matches(memberLoginDTO.getPassword(), findMember.getPassword());


### PR DESCRIPTION
## Motivation
- 장바구니 담기(추가)
- 장바구니 조회
기능 개발하였습니다.

## Key Changes
- BasketId에서 member 자료형 기존 Long형에서 String으로 변경하였습니다.
- 장바구니 담기 : header에서 jwt token 정보를 받아오고, Resquest Body로 itemId(상품 번호)를 받아와 BASKET 테이블에 저장합니다.
- 장바구니 조회 : header에서 jwt token 정보를 받아와 해당 회원의 장바구니 정보를 List로 반환합니다. 장바구니에서 Response로 basketId, itemId, category, bank, itemName, type을 넘겨줍니다.

## To reviewers
- 추후 HashMap 말고 DTO로 반환할 수 있게끔 리팩토링 하겠습니다.
- 장바구니 중복 추가 관련하여 처리 필요하면 추후 리팩토링 하겠습니다.
- BasketServiceImpl에서 returnSuccess(), returnFailed()는 추후 장바구니 삭제, 장바구니 비우기에서도 사용할 것 같아 미리 따로 메서드로 분리해놓았습니다.
- 아직 JPA에 대한 이해가 부족한 상태입니다. 사소한 것이라도 좋으니 리팩토링 할만한 것이 있으면 코드 리뷰 부탁드립니다 !