### PR TITLE
Feat: 회원 서비스 - 회원정보 수정/조회 개발 (#23)

### DIFF
--- a/src/main/java/com/example/miniprojectbe/controller/MemberController.java
+++ b/src/main/java/com/example/miniprojectbe/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.miniprojectbe.controller;
 import com.example.miniprojectbe.dto.MailDTO;
 import com.example.miniprojectbe.dto.MemberRequestDTO;
 import com.example.miniprojectbe.dto.MemberLoginDTO;
+import com.example.miniprojectbe.dto.MemberUpdateRequestDTO;
 import com.example.miniprojectbe.service.MemberService;
 import com.example.miniprojectbe.service.impl.CreateMailAndUpdatePwServiceImpl;
 import com.example.miniprojectbe.service.impl.SendMailServiceImpl;
@@ -66,5 +67,15 @@ public class MemberController {
         }
 
         return result;
+    }
+
+    @PatchMapping("/member/update")
+    public HashMap<String, String> updateMemberInfo(@RequestHeader(name = "Authorization") String header, MemberUpdateRequestDTO memberUpdateRequestDTO) {
+        return memberService.updateMemberInfo(header, memberUpdateRequestDTO);
+    }
+
+    @PostMapping("/member/info")
+    public HashMap<String, Object> getMemberInfo(@RequestHeader(name = "Authorization") String header) {
+        return memberService.getMemberInfo(header);
     }
 }

--- a/src/main/java/com/example/miniprojectbe/dto/MemberInfoResponseDTO.java
+++ b/src/main/java/com/example/miniprojectbe/dto/MemberInfoResponseDTO.java
@@ -1,0 +1,46 @@
+package com.example.miniprojectbe.dto;
+
+import com.example.miniprojectbe.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class MemberInfoResponseDTO {
+
+    private String memberId;
+    private String name;
+    private String birth;
+    private String job;
+    private String district;
+    private String bank;
+    private String category;
+
+    public Member toEntity(){
+        return Member.builder()
+                .memberId(memberId)
+                .name(name)
+                .birth(LocalDateTime.parse(birth))
+                .job(job)
+                .district(district)
+                .bank(bank)
+                .category(category)
+                .build();
+    }
+
+    public MemberInfoResponseDTO(Member member) {
+        this.memberId = member.getMemberId();
+        this.name = member.getName();
+        this.birth = String.valueOf(member.getBirth());
+        this.job = member.getJob();
+        this.district = member.getDistrict();
+        this.bank = member.getBank();
+        this.category = member.getCategory();
+    }
+}

--- a/src/main/java/com/example/miniprojectbe/dto/MemberUpdateRequestDTO.java
+++ b/src/main/java/com/example/miniprojectbe/dto/MemberUpdateRequestDTO.java
@@ -1,0 +1,37 @@
+package com.example.miniprojectbe.dto;
+
+import com.example.miniprojectbe.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class MemberUpdateRequestDTO {
+
+    private String password;
+    private String name;
+    private String birth;
+    private String job;
+    private String district;
+    private String bank;
+    private String category;
+
+    public Member toEntity(){
+        return Member.builder()
+                .password(password)
+                .name(name)
+                .birth(LocalDateTime.parse(birth))
+                .job(job)
+                .district(district)
+                .bank(bank)
+                .category(category)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/miniprojectbe/entity/Member.java
+++ b/src/main/java/com/example/miniprojectbe/entity/Member.java
@@ -1,5 +1,6 @@
 package com.example.miniprojectbe.entity;
 
+import com.example.miniprojectbe.dto.MemberUpdateRequestDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,4 +45,14 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Basket> basketList;
+
+    public void updateMember(MemberUpdateRequestDTO memberUpdateRequestDTO) {
+        password = memberUpdateRequestDTO.getPassword();
+        name = memberUpdateRequestDTO.getName();
+        birth = LocalDateTime.parse(memberUpdateRequestDTO.getBirth());
+        job = memberUpdateRequestDTO.getJob();
+        district = memberUpdateRequestDTO.getDistrict();
+        bank = memberUpdateRequestDTO.getBank();
+        category = memberUpdateRequestDTO.getCategory();
+    }
 }

--- a/src/main/java/com/example/miniprojectbe/jwt/JwtProvider.java
+++ b/src/main/java/com/example/miniprojectbe/jwt/JwtProvider.java
@@ -69,4 +69,9 @@ public class JwtProvider { //토큰 생성 및 검증 객체
     private String extractToken(String header) { //Bearer 떼어내는 메서드
         return header.substring(jwtProperties.getTokenPrefix().length());
     }
+
+    public String getMemberIdByHeader(String header) {
+        MemberLoginDTO memberLoginDTO = getMemberDTO(header);
+        return memberLoginDTO.getMemberId();
+    }
 }

--- a/src/main/java/com/example/miniprojectbe/repository/BlacklistRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/BlacklistRepository.java
@@ -2,7 +2,6 @@ package com.example.miniprojectbe.repository;
 
 import com.example.miniprojectbe.entity.Blacklist;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 public interface BlacklistRepository extends JpaRepository<Blacklist, String> {
 

--- a/src/main/java/com/example/miniprojectbe/service/MemberService.java
+++ b/src/main/java/com/example/miniprojectbe/service/MemberService.java
@@ -2,6 +2,7 @@ package com.example.miniprojectbe.service;
 
 import com.example.miniprojectbe.dto.MemberRequestDTO;
 import com.example.miniprojectbe.dto.MemberLoginDTO;
+import com.example.miniprojectbe.dto.MemberUpdateRequestDTO;
 import com.example.miniprojectbe.entity.Member;
 
 import java.util.HashMap;
@@ -14,4 +15,6 @@ public interface MemberService {
     boolean checkEmailDuplicate(String memberId);
     String findPassword(String memberId, String name);
     Member findMemberByMemberId(String memberId);
+    HashMap<String, String> updateMemberInfo(String header, MemberUpdateRequestDTO memberUpdateRequestDTO);
+    HashMap<String, Object> getMemberInfo(String header);
 }

--- a/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.miniprojectbe.service.impl;
 
 import com.example.miniprojectbe.dto.BasketResponseDTO;
-import com.example.miniprojectbe.dto.MemberLoginDTO;
 import com.example.miniprojectbe.entity.Basket;
 import com.example.miniprojectbe.entity.Item;
 import com.example.miniprojectbe.entity.Member;
@@ -29,7 +28,7 @@ public class BasketServiceImpl implements BasketService {
     @Override
     public HashMap<String, String> addCart(String header, Long itemId) {
         try {
-            String memberId = getMemberIdByHeader(header);
+            String memberId = jwtProvider.getMemberIdByHeader(header);
 
             Member member = memberService.findMemberByMemberId(memberId);
             Item item = itemService.findItemByItemId(itemId);
@@ -50,7 +49,7 @@ public class BasketServiceImpl implements BasketService {
         HashMap<String, Object> result = new HashMap<>();
 
         try {
-            String memberId = getMemberIdByHeader(header);
+            String memberId = jwtProvider.getMemberIdByHeader(header);
             List<BasketResponseDTO> basketResponseDTOS = basketRepository.findByMember_MemberId(memberId)
                     .stream()
                     .map(BasketResponseDTO::new)
@@ -65,11 +64,6 @@ public class BasketServiceImpl implements BasketService {
             return result;
         }
         return result;
-    }
-
-    private String getMemberIdByHeader(String header) {
-        MemberLoginDTO memberLoginDTO = jwtProvider.getMemberDTO(header);
-        return memberLoginDTO.getMemberId();
     }
 
     private HashMap<String, String> returnFailed() {

--- a/src/main/java/com/example/miniprojectbe/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/MemberServiceImpl.java
@@ -1,8 +1,7 @@
 package com.example.miniprojectbe.service.impl;
 
 
-import com.example.miniprojectbe.dto.MemberLoginDTO;
-import com.example.miniprojectbe.dto.MemberRequestDTO;
+import com.example.miniprojectbe.dto.*;
 import com.example.miniprojectbe.entity.Blacklist;
 import com.example.miniprojectbe.entity.Member;
 import com.example.miniprojectbe.jwt.JwtProvider;
@@ -13,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 import java.time.LocalDateTime;
@@ -104,6 +104,50 @@ public class MemberServiceImpl implements MemberService {
             log.error("해당 memberId와 일치하는 회원이 없습니다.");
             return null;
         }
+    }
+
+    @Transactional
+    @Override
+    public HashMap<String, String> updateMemberInfo(String header, MemberUpdateRequestDTO memberUpdateRequestDTO) {
+
+        HashMap<String, String> result = new HashMap<>();
+
+        try {
+            String memberId = jwtProvider.getMemberIdByHeader(header);
+            Member member = findMemberByMemberId(memberId);
+
+            memberUpdateRequestDTO.setPassword(passwordEncoder.encode(memberUpdateRequestDTO.getPassword()));
+            member.updateMember(memberUpdateRequestDTO);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            result.put("resultCode", "failed");
+            return result;
+        }
+        result.put("resultCode", "success");
+        return result;
+    }
+
+    @Override
+    public HashMap<String, Object> getMemberInfo(String header) {
+        HashMap<String, Object> result = new HashMap<>();
+
+        try {
+            String memberId = jwtProvider.getMemberIdByHeader(header);
+            Member member = findMemberByMemberId(memberId);
+            if (member!=null) {
+                MemberInfoResponseDTO findMember = new MemberInfoResponseDTO(member);
+                result.put("resultCode", "success");
+                result.put("resultData", findMember);
+                return result;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            result.put("resultCode", "failed");
+            return result;
+        }
+        result.put("resultCode", "failed");
+        return result;
     }
 
     private boolean isValidPassword(MemberLoginDTO memberLoginDTO, Member findMember) {


### PR DESCRIPTION
## Motivation
회원정보 수정 개발
회원정보 조회 개발

## Key Changes
- JwtProvider에 getMemberIdByHeader(header에 있는 jwt token 정보로 memberId를 반환하는 메서드) 추가해놓았습니다 ! 회원 연관된 부분 개발하시는 분들은 header에서 회원 정보 가져오는 것이 필요할 때 JwtProvider 주입받아서 이 메서드 활용하시면 될 것 같습니다.
- 회원정보 수정 : header에서 회원 정보를 가져와 해당 회원의 회원정보를 수정한다. 비밀번호 수정 시 암호화 되어 수정됨. 아이디(memberId)는 수정 불가함.
- 회원정보 조회 : header에 있는 jwt token으로 회원 정보를 가져와 반환함. password 정보는 제외함.

## To reviewers
HashMap 추후 DTO로 리팩토링 하겠습니다 ..
