### PR TITLE
Feat: 추천 서비스 - 회원 맞춤 상품 추천 서비스 구현 (#35)

### DIFF
--- a/src/main/java/com/example/miniprojectbe/controller/RecommendController.java
+++ b/src/main/java/com/example/miniprojectbe/controller/RecommendController.java
@@ -9,6 +9,7 @@ import com.example.miniprojectbe.service.RecommendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
@@ -32,6 +33,23 @@ public class RecommendController {
         }
         else {
             return recommendService.recommendLoanList(bank,category);
+        }
+    }
+
+    @GetMapping("/customRecommend")
+    public HashMap<String, Object> getCustomRecommendList(@RequestHeader(name = "Authorization") String header, @RequestParam(name = "page") int page) {
+        MemberLoginDTO memberLoginDTO = jwtProvider.getMemberDTO(header);
+        MemberInfoResponseDTO findMember = memberService.findMemberInfoByMemberId(memberLoginDTO.getMemberId());
+        String bank = findMember.getBank();
+        String category = findMember.getCategory();
+        String preference = findMember.getDistrict();
+        String target = findMember.getJob();
+
+        if (category.equals("정기예금") || category.equals("적금")) {
+            return recommendService.recommendCustomDepositList(bank, category, preference, target, page);
+        }
+        else {
+            return recommendService.recommendCustomLoanList(bank, category, preference, target, page);
         }
     }
 }

--- a/src/main/java/com/example/miniprojectbe/dto/RecommendDepositResponseDTO.java
+++ b/src/main/java/com/example/miniprojectbe/dto/RecommendDepositResponseDTO.java
@@ -20,7 +20,6 @@ public class RecommendDepositResponseDTO {
     private String type;
     private BigDecimal rate;
     private BigDecimal prefRate;
-    private String mature;
 
     public RecommendDepositResponseDTO(Deposit deposit) {
         this.itemId = deposit.getItemId();
@@ -30,7 +29,6 @@ public class RecommendDepositResponseDTO {
         this.type = deposit.getType();
         this.rate = deposit.getRate();
         this.prefRate = deposit.getPrefRate();
-        this.mature = deposit.getMature();
     }
 
 }

--- a/src/main/java/com/example/miniprojectbe/dto/RecommendLoanResponseDTO.java
+++ b/src/main/java/com/example/miniprojectbe/dto/RecommendLoanResponseDTO.java
@@ -20,7 +20,6 @@ public class RecommendLoanResponseDTO {
     private String type;
     private BigDecimal minRate;
     private BigDecimal maxRate;
-    private String delay;
 
     public RecommendLoanResponseDTO (Loan loan) {
         this.itemId = loan.getItemId();
@@ -30,7 +29,6 @@ public class RecommendLoanResponseDTO {
         this.type = loan.getType();
         this.minRate = loan.getMinRate();
         this.maxRate = loan.getMaxRate();
-        this.delay = loan.getDelay();
     }
 
 }

--- a/src/main/java/com/example/miniprojectbe/repository/DepositRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/DepositRepository.java
@@ -13,5 +13,6 @@ public interface DepositRepository extends JpaRepository<Deposit, Long> {
     List<Deposit> findAllByBankContainingOrItemNameContaining(String content1, String content2);
     Slice<Deposit> findAllByCategory(String category, PageRequest pageRequest);
     List<Deposit> findTop3ByBankAndCategoryOrderByRateDesc(String bank, String category);
+    Slice<Deposit> findByBankOrCategoryOrPreferenceOrTargetOrderByRateDesc(String bank, String category, String preference, String target, PageRequest pageRequest);
 
 }

--- a/src/main/java/com/example/miniprojectbe/repository/LoanRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/LoanRepository.java
@@ -1,5 +1,6 @@
 package com.example.miniprojectbe.repository;
 
+import com.example.miniprojectbe.entity.Deposit;
 import com.example.miniprojectbe.entity.Loan;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -14,5 +15,7 @@ public interface LoanRepository extends JpaRepository<Loan, Long> {
     List<Loan> findAllByBankContainingOrItemNameContaining(String content1, String content2);
 
     List<Loan> findTop3ByBankAndCategoryOrderByMinRateAsc(String bank, String category);
+
+    Slice<Loan> findByBankOrCategoryOrPreferenceOrTargetOrderByMinRateAsc(String bank, String category, String preference, String target, PageRequest pageRequest);
 
 }

--- a/src/main/java/com/example/miniprojectbe/service/RecommendService.java
+++ b/src/main/java/com/example/miniprojectbe/service/RecommendService.java
@@ -6,4 +6,7 @@ public interface RecommendService {
 
     HashMap<String, Object> recommendDepositList(String bank, String category);
     HashMap<String, Object> recommendLoanList(String bank, String category);
+    HashMap<String, Object> recommendCustomDepositList(String bank, String category, String preference, String target, int page);
+    HashMap<String, Object> recommendCustomLoanList(String bank, String category, String preference, String target, int page);
+
 }

--- a/src/main/java/com/example/miniprojectbe/service/impl/RecommendServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/RecommendServiceImpl.java
@@ -8,6 +8,8 @@ import com.example.miniprojectbe.repository.ItemRepository;
 import com.example.miniprojectbe.repository.LoanRepository;
 import com.example.miniprojectbe.service.RecommendService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -51,6 +53,50 @@ public class RecommendServiceImpl implements RecommendService {
                     .stream()
                     .map(RecommendLoanResponseDTO::new)
                     .collect(Collectors.toList());
+
+            result.put("resultCode", "success");
+            result.put("resultData", recommendLoanResponseDTOS);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            result.put("resultCode", "failed");
+            return result;
+        }
+
+        return result;
+    }
+
+    @Override
+    public HashMap<String, Object> recommendCustomDepositList(String bank, String category, String preference, String target, int page) {
+        PageRequest pageRequest = PageRequest.of(page - 1, 10);
+        HashMap<String, Object> result = new HashMap<>();
+
+        try {
+            Slice<RecommendDepositResponseDTO> recommendDepositResponseDTOS
+                    = depositRepository.findByBankOrCategoryOrPreferenceOrTargetOrderByRateDesc(bank, category, preference, target, pageRequest)
+                                        .map(RecommendDepositResponseDTO::new);
+
+            result.put("resultCode", "success");
+            result.put("resultData", recommendDepositResponseDTOS);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            result.put("resultCode", "failed");
+            return result;
+        }
+
+        return result;
+    }
+
+    @Override
+    public HashMap<String, Object> recommendCustomLoanList(String bank, String category, String preference, String target, int page) {
+        PageRequest pageRequest = PageRequest.of(page - 1, 10);
+        HashMap<String, Object> result = new HashMap<>();
+
+        try {
+            Slice<RecommendLoanResponseDTO> recommendLoanResponseDTOS
+                    = loanRepository.findByBankOrCategoryOrPreferenceOrTargetOrderByMinRateAsc(bank, category, preference, target, pageRequest)
+                                    .map(RecommendLoanResponseDTO::new);
 
             result.put("resultCode", "success");
             result.put("resultData", recommendLoanResponseDTOS);


### PR DESCRIPTION
## Motivation

메인페이지가 아닌 맞춤상품 페이지에서 보여주는 추천서비스입니다.
메인페이지에서 보여주는 추천상품은 최대 3가지로 선호은행과 선호 상품 종류 두가지 정보를 동시에 반영하여 리스트

회원가입 시 추천받고 싶은 상품 종류를
정기예금 / 적금을 선택한 회원은 정기예금 / 적금 데이터에서 회원정보와 일치하는 데이터들을 리스트
전세자금대출 / 주택담보대출을 선택한 회원은 전세자금대출 / 주택담보대출 데이터에서 회원정보와 일치하는 데이터들을 리스트


## Key Changes

- 정기예금 / 적금 상품 중 회원정보와 알맞는 데이터들을 리스트 (직업, 지역, 선호 은행 참고)
- 전세자금대출 / 주택담보대출 상품 중 회원정보와 알맞는 데이터들을 리스트 (직업, 지역, 선호 은행 참고)

## To reviewers

코드 리뷰 잘 부탁드리겠씁니다 ! 화이팅 합시다 !!
