### PR TITLE
Feat: 장바구니 서비스 - 장바구니 추가 시 이미 장바구니에 존재하는 상품은 추가 안되게 하는 기능 개발 (#28)

### DIFF
--- a/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
@@ -2,6 +2,8 @@ package com.example.miniprojectbe.repository;
 
 import com.example.miniprojectbe.dto.BasketId;
 import com.example.miniprojectbe.entity.Basket;
+import com.example.miniprojectbe.entity.Item;
+import com.example.miniprojectbe.entity.Member;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -21,4 +23,6 @@ public interface BasketRepository extends JpaRepository<Basket, BasketId> {
     @Modifying
     @Query("delete from Basket basket where basket.member.memberId = :memberId")
     void deleteByMemberId(@Param("memberId") String memberId);
+
+    boolean existsByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
@@ -34,8 +34,14 @@ public class BasketServiceImpl implements BasketService {
             Member member = memberService.findMemberByMemberId(memberId);
             Item item = itemService.findItemByItemId(itemId);
 
-            Basket basket = Basket.builder().member(member).item(item).build();
-            basketRepository.save(basket);
+            if (basketRepository.existsByMemberAndItem(member, item)) {
+                HashMap<String, String> result = new HashMap<>();
+                result.put("resultCode", "duplicate");
+                return result;
+            } else {
+                Basket basket = Basket.builder().member(member).item(item).build();
+                basketRepository.save(basket);
+            }
 
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
## Motivation
장바구니 추가 시 이미 장바구니에 존재하는 상품은 추가 안되게 하는 기능 개발 (장바구니에 중복 상품 담길 수 없음)

## Key Changes
- 장바구니 추가 시 이미 장바구니에 존재하는 상품은 추가 안되게 하는 기능 개발

[feat:](https://github.com/KDT3-MiniProject-8/MiniProject-BE/commit/bd6b8d4717663c43cca7d46c62d5c3ed74c9d1e6) https://github.com/KDT3-MiniProject-8/MiniProject-BE/issues/28 [- existsByMemberAndItem 추가](https://github.com/KDT3-MiniProject-8/MiniProject-BE/commit/bd6b8d4717663c43cca7d46c62d5c3ed74c9d1e6) 

- existsByMemberAndItem : 매개변수로 받은 Member와 Item에 해당하는 Basket이 있는지 확인함. (boolean형으로 반환)

[refactor:](https://github.com/KDT3-MiniProject-8/MiniProject-BE/commit/0df17544349e44ee83d8b02b283f84c564d6b519) https://github.com/KDT3-MiniProject-8/MiniProject-BE/issues/28 [- 장바구니 추가 시 이미 장바구니에 담겨있는 상품이면 추가되지 않도록 로직 변경](https://github.com/KDT3-MiniProject-8/MiniProject-BE/commit/0df17544349e44ee83d8b02b283f84c564d6b519) 

- 장바구니 추가 요청 시 이미 해당 회원이 가지고 있는 상품이라면 추가되지 못하도록 코드 변경
- 중복 상품 장바구니 추가 요청 시 { resultCode : duplicate } 반환함

## To reviewers


