### PR TITLE
Refactor: 장바구니 서비스 - 장바구니 조회 시 예적금/대출 따로 나눠서 보여줄 수 있게 분리 (api 분리) (#29)

### DIFF
--- a/src/main/java/com/example/miniprojectbe/controller/BasketController.java
+++ b/src/main/java/com/example/miniprojectbe/controller/BasketController.java
@@ -18,10 +18,16 @@ public class BasketController {
         return basketService.addCart(header, itemId);
     }
 
-    // 장바구니 조회
-    @GetMapping("/api/cartList")
-    public HashMap<String, Object> getCartList(@RequestHeader(name = "Authorization") String header) {
-        return basketService.getCartList(header);
+    // 장바구니 조회 (예적금)
+    @GetMapping("/api/deposit/cartList")
+    public HashMap<String, Object> getDepositCartList(@RequestHeader(name = "Authorization") String header, @RequestParam int page) {
+        return basketService.getDepositCartList(header, page);
+    }
+
+    // 장바구니 조회 (대출)
+    @GetMapping("/api/loan/cartList")
+    public HashMap<String, Object> getLoanCartList(@RequestHeader(name = "Authorization") String header, @RequestParam int page) {
+        return basketService.getLoanCartList(header, page);
     }
 
     // 장바구니 상품 삭제 (1개)

--- a/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
@@ -4,6 +4,8 @@ import com.example.miniprojectbe.dto.BasketId;
 import com.example.miniprojectbe.entity.Basket;
 import com.example.miniprojectbe.entity.Item;
 import com.example.miniprojectbe.entity.Member;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -25,4 +27,7 @@ public interface BasketRepository extends JpaRepository<Basket, BasketId> {
     void deleteByMemberId(@Param("memberId") String memberId);
 
     boolean existsByMemberAndItem(Member member, Item item);
+
+    @EntityGraph(attributePaths = {"member", "item"})
+    Slice<Basket> findByMember_MemberIdAndItem_CategoryOrItem_Category(String memberId, String category1, String category2, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/miniprojectbe/service/BasketService.java
+++ b/src/main/java/com/example/miniprojectbe/service/BasketService.java
@@ -5,7 +5,8 @@ import java.util.HashMap;
 public interface BasketService {
 
     HashMap<String, String> addCart(String header, Long itemId);
-    HashMap<String, Object> getCartList(String header);
+    HashMap<String, Object> getDepositCartList(String header, int page);
+    HashMap<String, Object> getLoanCartList(String header, int page);
     HashMap<String, String> deleteCartByBasketId(Long basketId);
     HashMap<String, String> deleteAllCartsByHeader(String header);
 }

--- a/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
@@ -10,12 +10,12 @@ import com.example.miniprojectbe.repository.ItemRepository;
 import com.example.miniprojectbe.repository.MemberRepository;
 import com.example.miniprojectbe.service.BasketService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -51,16 +51,26 @@ public class BasketServiceImpl implements BasketService {
     }
 
     @Override
-    public HashMap<String, Object> getCartList(String header) {
+    public HashMap<String, Object> getDepositCartList(String header, int page) {
 
+        return getCartList(header, page, "정기예금", "적금");
+    }
+
+    @Override
+    public HashMap<String, Object> getLoanCartList(String header, int page) {
+
+        return getCartList(header, page, "주택담보대출", "전세자금대출");
+    }
+
+    private HashMap<String, Object> getCartList(String header, int page, String category1, String category2) {
+
+        PageRequest pageRequest = PageRequest.of(page - 1, 10);
         HashMap<String, Object> result = new HashMap<>();
 
         try {
             String memberId = jwtProvider.getMemberIdByHeader(header);
-            List<BasketResponseDTO> basketResponseDTOS = basketRepository.findByMember_MemberId(memberId)
-                    .stream()
-                    .map(BasketResponseDTO::new)
-                    .collect(Collectors.toList());
+            Slice<BasketResponseDTO> basketResponseDTOS = basketRepository.findByMember_MemberIdAndItem_CategoryOrItem_Category(memberId, category1, category2, pageRequest)
+                    .map(BasketResponseDTO::new);
 
             result.put("resultCode", "success");
             result.put("resultData", basketResponseDTOS);


### PR DESCRIPTION
## Motivation
장바구니 서비스 - 장바구니 조회 시 예적금/대출 따로 나눠서 보여줄 수 있게 분리 (api 분리)

## Key Changes
[refactor:](https://github.com/KDT3-MiniProject-8/MiniProject-BE/commit/2f2e3d51c5977d0c71b42c0970cc32572bdaab2e) https://github.com/KDT3-MiniProject-8/MiniProject-BE/issues/29 [- 장바구니 조회 시 예적금/대출 따로 나눠서 보여줄 수 있게 분리 (api 분리)](https://github.com/KDT3-MiniProject-8/MiniProject-BE/commit/2f2e3d51c5977d0c71b42c0970cc32572bdaab2e) 

- 기존 장바구니 조회는 해당 멤버가 담은 모든 상품을 예적금/대출 상관없이 한번에 보여주고 있었음.
- 예적금 장바구니 / 대출 장바구니 분리하여 다른 api로 만듦.
- 조회 시 Slice 처리 (프론트에서 무한스크롤 구현)

## To reviewers
꼼꼼한 코드리뷰 부탁드립니닷 ㅎㅎ
