### PR TITLE
Refactor: 로그인시 nullpointerException 해결, 장바구니 리스트 조회 코드 수정, PUBLIC_URLS 추가 (#44)

### DIFF
--- a/src/main/java/com/example/miniprojectbe/dto/MemberLoginDTO.java
+++ b/src/main/java/com/example/miniprojectbe/dto/MemberLoginDTO.java
@@ -18,8 +18,6 @@ public class MemberLoginDTO {
 
     private String memberId;
     private String password;
-    private String bank;
-    private String category;
 
     public MemberLoginDTO(Claims claims) {
         this.memberId = claims.get("memberId", String.class);

--- a/src/main/java/com/example/miniprojectbe/jwt/JwtProvider.java
+++ b/src/main/java/com/example/miniprojectbe/jwt/JwtProvider.java
@@ -49,7 +49,7 @@ public class JwtProvider { //토큰 생성 및 검증 객체
             log.error("토큰이 존재하지 않습니다.(2)");
         }
 
-        return null;
+        return new MemberLoginDTO();
     }
 
     public Claims tokenToMember(String token) { //토큰 값을 claims로 바꿔줘서 리턴

--- a/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
+++ b/src/main/java/com/example/miniprojectbe/repository/BasketRepository.java
@@ -29,5 +29,6 @@ public interface BasketRepository extends JpaRepository<Basket, BasketId> {
     boolean existsByMemberAndItem(Member member, Item item);
 
     @EntityGraph(attributePaths = {"member", "item"})
-    Slice<Basket> findByMember_MemberIdAndItem_CategoryOrItem_Category(String memberId, String category1, String category2, PageRequest pageRequest);
+    @Query("SELECT b FROM Basket b WHERE b.member.memberId = :memberId AND b.item.category IN (:category)")
+    Slice<Basket> findByMemberIdAndCategory(String memberId, List<String> category, PageRequest pageRequest);
 }

--- a/src/main/java/com/example/miniprojectbe/security/SecurityConfig.java
+++ b/src/main/java/com/example/miniprojectbe/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_URLS = { // 이 URL은 권한검사 하지 않음
             "/signup", "/login", "/", "/logout", "/findPw", "/findPw/sendMail",
-            "/depositList", "/savingsList","/mortgageLoan", "/charterLoan"
+            "/depositList", "/savingsList","/mortgageLoan", "/charterLoan", "/api/duplication/{memberId}"
 
     };
 

--- a/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
+++ b/src/main/java/com/example/miniprojectbe/service/impl/BasketServiceImpl.java
@@ -15,7 +15,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -52,24 +54,28 @@ public class BasketServiceImpl implements BasketService {
 
     @Override
     public HashMap<String, Object> getDepositCartList(String header, int page) {
-
-        return getCartList(header, page, "정기예금", "적금");
+        List<String> category = new ArrayList<>();
+        category.add("정기예금");
+        category.add("적금");
+        return getCartList(header, category, page);
     }
 
     @Override
     public HashMap<String, Object> getLoanCartList(String header, int page) {
-
-        return getCartList(header, page, "주택담보대출", "전세자금대출");
+        List<String> category = new ArrayList<>();
+        category.add("전세자금대출");
+        category.add("주택담보대출");
+        return getCartList(header, category, page);
     }
 
-    private HashMap<String, Object> getCartList(String header, int page, String category1, String category2) {
+    private HashMap<String, Object> getCartList(String header, List<String> category, int page) {
 
         PageRequest pageRequest = PageRequest.of(page - 1, 10);
         HashMap<String, Object> result = new HashMap<>();
 
         try {
             String memberId = jwtProvider.getMemberIdByHeader(header);
-            Slice<BasketResponseDTO> basketResponseDTOS = basketRepository.findByMember_MemberIdAndItem_CategoryOrItem_Category(memberId, category1, category2, pageRequest)
+            Slice<BasketResponseDTO> basketResponseDTOS = basketRepository.findByMemberIdAndCategory(memberId, category, pageRequest)
                     .map(BasketResponseDTO::new);
 
             result.put("resultCode", "success");


### PR DESCRIPTION
## Motivation

로그인 기능은 잘되었으나 로그에 nullpointerException 에러를 발견하였는데 이를 해결하였습니다
장바구니 리스트 조회 시 카테고리명만 같으면 다른 멤버의 리스트도 조회되는 에러를 발견하였는데 이를 해결하였습니다
아이디 중복확인 url이 PUBLIC_URLS에 추가하였습니다

## Key Changes

- 로그인시 nullpointerException 해결
- 장바구니 리스트 조회 코드 수정 완료
- PUBLIC_URLS에 아이디 중복확인 url 추가

## To reviewers

코드 리뷰 부탁드리겠습니다 !

